### PR TITLE
Change seven col to eight

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -64,7 +64,7 @@
 
 <section class="row row--cloud-products strip">
   <div class="strip-inner-wrapper">
-    <div class="four-col prepend-seven">
+    <div class="four-col prepend-eight">
       <h2><a href="/cloud/openstack/managed-cloud">Let us host your OpenStack cloud&nbsp;&rsaquo;</a></h2>
       <p>With BootStack, we design, build and run your private cloud infrastructure without vendor lock-in.</p>
     </div>


### PR DESCRIPTION
## Done

Add column to OpenStack section 

Related PR: https://github.com/canonical-websites/www.ubuntu.com/pull/1508

Related comment: https://github.com/canonical-websites/www.ubuntu.com/pull/1508#issuecomment-293531220

## QA

- Pull code and run ./run
- Go to http://localhost:8001/
- Check that the content in the 'Let us host your OpenStack cloud’ section has moved by one column
- [Karl’s demo](http://www.ubuntu.com-remove-mobile-from-homepage.demo.haus/) 